### PR TITLE
Use ConTeXt style for setups and macros

### DIFF
--- a/context/caesar/t-caesar.tex
+++ b/context/caesar/t-caesar.tex
@@ -1,10 +1,10 @@
 %D \module
-%D   [     file=caesar.tex, 
+%D   [     file=t-caesar.tex, 
 %D      version=0.55,
 %D        title=caesar, 
 %D     subtitle=sidenotes,
 %D       author=Andy Thomas,
-%D         date=120523, 
+%D         date=2012.05.27, 
 %D    copyright=Andy Thomas, 
 %D      license=Public Domain]
 
@@ -29,6 +29,8 @@
 \setuppagenumbering[alternative=doublesided]
 
 % setup the side notes
+\setupmargindata[stack=continue]
+
 \setupmargindata
     [margintext]
     [location=outer,
@@ -60,6 +62,15 @@
     [fullwidth] 
     [alternative=command, 
      command=\caesar_fullwidth_command] 
+
+% put citations in the margin
+\unexpanded\def\sidecite{\dodoubleargument\sidecite_indeed}
+\def\sidecite_indeed[#1][#2]%
+    {\getparameters[caesar_sidecite_][left=,right=,#1]%
+      \margintext
+          {\caesar_sidecite_left
+           \cite[data][#2]%
+           \caesar_sidecite_right}}
 
 % Enable old style numbers and protrusion
 \definefontfeature[default][default][onum=yes, protrusion=quality, expansion=quality]
@@ -104,28 +115,65 @@
     before={\blank[2*big]},
   ]
 
-% use backspace as location anchor 
-\setupfloats[indentnext=no, location=inner]
-
 % setup the captions
 \setupcaption[style={\tfx\setupinterlinespace[line=10pt]}, headstyle=\rm, suffix={:}]
+\setupcaption[table][minwidth=\hsize, width=\hsize]
 
-%
-% High level macros start here
+\defineexternalfigure[marginwidth] [width=\layoutparameter\c!rightmargin]
+\defineexternalfigure[textwidth]   [width=\textwidth]
+\defineexternalfigure[fullwidth]   [width=\the\dimexpr\textwidth+\measure{fullwidth_extra}\relax]
 
-%setup the figures in 3 sizes
-\define[2]\largefigure{\placefigure[here,top,bottom,page][#1]{#2}{\externalfigure[#1][width=400pt]}}%
-\define[2]\normalfigure{\placefigure[here,top,bottom,page][#1]{#2}{\externalfigure[#1][width=280pt]}}%
-\define[2]\smallfigure{\margintext{\placefigure[here][#1]{#2}{\externalfigure[#1][width=100pt]}}}%
+\setupfloat[figure][indentnext=no, location=inner, default={here,top,bottom,page}]
+\setupfloat[table] [indentnext=no, location=inner, default={here,top,bottom,page}]
 
-%setup the tables in 3 sizes
-\define[3]\largetable{\setupcaption[width=400pt]\placetable[here][#1]{#2}#3\setupcaption[width=fit]}
-\define[3]\normaltable{\setupcaption[width=280pt]\placetable[here][#1]{#2}#3\setupcaption[width=fit]}
-\define[3]\smalltable{\setupcaption[width=100pt]\margintext{\placetable[here][#1]{#2}#3}\setupcaption[width=fit]}
+% \placefigure[outermargin] does not play nice with margintext.
+% We need \margintext{\palcefigure[...]{...}}
+% So we define wrappers with the same interface as default ConTeXt commands
 
-% put citations in the margin
-\def\sidecite{\dodoubleempty\doSidecite}
-\def\doSidecite[#1][#2]#3{\margintext{#1\cite[data][#3]#2}}
+\unexpanded\def\placemarginfigure
+    {\dodoubleargument\caesar_placemarginfigure_indeed}
+
+% Beware, we override the figure location!
+\def\caesar_placemarginfigure_indeed[#1][#2]#3#4%
+    {\ifsecondargument
+       \margintext{\placefigure[here][#2]{#3}{#4}}%
+     \else
+       \margintext{\placefigure[here][#1]{#3}{#4}}%
+     \fi}
+
+\unexpanded\def\startplacemarginfigure
+    {\dosingleargument\caesar_start_place_margin_figure}
+
+\def\caesar_start_place_margin_figure[#1]#2\stopplacemarginfigure
+    {\margintext
+      {\startplacefigure[#1, location=here]% Beware, we override location!
+       #2%
+      \stopplacefigure}}
+
+\definefloat [widetable][widetables][table]
+\setupcaption[widetable][width=\the\dimexpr\textwidth+\measure{fullwidth_extra}\relax]
+
+% Margin table is same as margin figure but 
+% the following does not work if | in used in the table
+\unexpanded\def\placemargintable
+    {\dodoubleargument\caesar_placemargintable_indeed}
+
+% Beware, we override the table location!
+\def\caesar_placemargintable_indeed[#1][#2]#3#4%
+    {\ifsecondargument
+       \margintext{\placetable[here][#2]{#3}{#4}}%
+     \else
+       \margintext{\placetable[here][#1]{#3}{#4}}%
+     \fi}
+
+\unexpanded\def\startplacemargintable
+    {\dosingleargument\caesar_start_place_margin_table}
+
+\def\caesar_start_place_margin_table[#1]#2\stopplacemargintable
+    {\margintext
+      {\startplacetable[#1, location=here]% Beware, we override location!
+        #2%
+      \stopplacetable}}
 
 \setvariables
   [titlepage]

--- a/context/example/caesar_example.tex
+++ b/context/example/caesar_example.tex
@@ -18,48 +18,59 @@
 
 \title{Contents} 
 \placelist[chapter]
+
+\title{Tables}
+\placelist[table,widetable]
 %
 \chapter{Examples}
 The first thing to do is to type some plain text in the document. No surprises here.
 The layout has ample margins to allow annotations on the page.\annotation{All information is on the same page, no turning of pages is necessary.} 
-For more information about this concept compare e.g.\ the books of Edward Tufte.\sidecite[See e.g.\ ][ And other Tufte books.]{Tufte1990,Tufte2006}
+For more information about this concept compare e.g.\ the books of Edward Tufte.\sidecite[left={See e.g.\ }, right={ And other Tufte books.}][Tufte1990,Tufte2006]
 % A section with a couple of figures
 \section{Figures}
-\smallfigure{rectangle}{A small rectangle put in the margin.}%
+\startplacemarginfigure[ title={A small rectangle put in the margin.}, reference=rectangle]
+  \externalfigure[rectangle][marginwidth]
+\stopplacemarginfigure
+
 There are a couple of options to include figures in the document. The first one is a figure in the margin.
-Figure \in[rectangle] shows that with a small rectangle. The next alternative is a figure in the text frame. %
+\in{Figure}[rectangle] shows that with a small rectangle. The next alternative is a figure in the text frame. %
 %
-\normalfigure{rectangle2}{A larger rectangle in the main area of the text, i.e.\ it does not span into the margin.}%
+\startplacefigure[title={A larger rectangle in the main area of the text, i.e.\ it does not span into the margin.},
+  reference=rectangle2]
+  \externalfigure[rectangle2][textwidth]
+\stopplacefigure
 %
-This larger rectangle is displayed in figure \in[rectangle2]. In case that an even wider figure is needed, the third option spans over the text as well as the margin area. The three options make it easy to choose the appropriate size for a given input file. 
+This larger rectangle is displayed in \in{figure}[rectangle2]. In case that an even wider figure is needed, the third option spans over the text as well as the margin area. The three options make it easy to choose the appropriate size for a given input file. 
 %
-\largefigure{rectangle3}{An even larger rectangle. This is the widest figure option. Both, the text as well as the margin width are used for the diagram.}%
+\startplacefigure[title={An even larger rectangle. This is the widest figure option. Both, the text as well as the margin width are used for the diagram.}]
+  \externalfigure[rectangle3][fullwidth]
+\stopplacefigure
 % Next section with a variety of tables
 \section{Tables}
 %
-\smalltable{table1}{A couple of numbers in a table in the margin.}{%
+\placemargintable[table1]{A couple of numbers in a table in the margin.}{%
 \starttable[|c|c|c|]
   \NC A \NC B \NC C\NC\SR
-\NC 0.50 \NC 0.47 \NC 0.48  \NC \FR
+  \NC 0.50 \NC 0.47 \NC 0.48  \NC \FR
 \stoptable
 }
 The same options are also available for tables.
 The first one is again a small one in the margin, this is shown in table \in[table1]. The next option is a table across the text width. %
 %
-\normaltable{table2}{A couple of numbers in a larger table. This table spans the usual text width.}{%
+\startplacetable[reference=table2, title={A couple of numbers in a larger table. This table spans the usual text width.}]
 \starttable[|c|c|c|c|c|c|c|c|]
   \NC  A \NC  B \NC C \NC D \NC E \NC F \NC G \NC H \NC \SR
 \NC 0.21	\NC 0.23 \NC 0.34 \NC 0.42 \NC 0.53 \NC 0.64 \NC 0.72	\NC 0.33 \NC\FR
 \stoptable
-}%
+\stopplacetable
 Table \in[table2] displays the larger table with a couple of numbers. The last choice is again a table over the full width of the page. This is demonstrated in table \in[table3].
 %
-\largetable{table3}{Even more numbers in a big table are shown here. This table spans across the full page, text width plus margin.}{%
+\startplacewidetable[reference={table3}, title={Even more numbers in a big table are shown here. This table spans across the full page, text width plus margin.}]
 \starttable[|c|c|c|c|c|c|c|c|c|c|c|c|]
   \NC  A \NC  B \NC C \NC D \NC E \NC F \NC G \NC H \NC I \NC J \NC K \NC \ L \NC  \SR
 \NC 0.21	\NC 0.23 \NC 0.34 \NC 0.42 \NC 0.53 \NC 0.64 \NC 0.72	\NC 0.33 \NC 0.22\NC 0.04 \NC 0.93 \NC 0.81 \NC\FR
 \stoptable
-}%
+\stopplacewidetable
 %
 \section{Text across the full page}
 Sometimes it can be useful to put some text across the whole page, which is similar to {\tt largefigure} and {\tt largetable}. This can be done as well, but it does not necessary work across page breaks.


### PR DESCRIPTION
I have refactored some of the code so that it is consistent with the ConTeXt style. In particular:
- Use key-value driven interface for titlepage
- Use key-value driven interface for sidecite
- Use ConTeXt style names for different types of figures and tables.
